### PR TITLE
Bootstrap v4 Beta 3 changed an scss map

### DIFF
--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -482,8 +482,7 @@ $custom-file-box-shadow: $input-box-shadow;
 $custom-file-button-color: $custom-file-color;
 $custom-file-button-bg: $input-group-addon-bg;
 $custom-file-text: (
-  placeholder: (en: "Choose file..."),
-  button-label: (en: "Browse")
+  en: "Browse"
 );
 
 // Form validation


### PR DESCRIPTION
The SCSS map for $custom-file-text has changed. Per this GH issue:
https://github.com/twbs/bootstrap/issues/25127

I looked at the _variables.scss file to find the updated map.


Edit:
Fixes this error you may see when viewing the application or in my case precompiling assets for deployment:

```Sass::SyntaxError: (en: "Choose file...") isn't a valid CSS value.```