### PR TITLE
Add Dropdown support

### DIFF
--- a/assets/javascripts/hootstrap.js
+++ b/assets/javascripts/hootstrap.js
@@ -1,4 +1,5 @@
 //= require hootstrap/alerts
+//= require hootstrap/dropdown
 //= require hootstrap/modal
 //= require hootstrap/rails
 //= require hootstrap/toast

--- a/assets/javascripts/hootstrap/dropdown.js
+++ b/assets/javascripts/hootstrap/dropdown.js
@@ -1,0 +1,71 @@
+//= require ./utils/dynamicListener
+//= require ./utils/turbolinks
+
+document.addEventListener(HootstrapEvent, () => {
+  let activeDropdown = {};
+
+  addDynamicEventListener(
+    document.body,
+    'click',
+    '[data-toggle="dropdown"]',
+    openDropdown
+  );
+
+  document.body.addEventListener('click', event => {
+    if (!event.target.classList.contains('dropdown-toggle')) {
+      closeDropdown();
+    }
+  });
+
+  document.addEventListener('keyup', handleKeyup);
+
+  function openDropdown(event) {
+    event.preventDefault();
+
+    const button = event.target;
+    const dropdown = button.parentNode;
+    const children = dropdown.childNodes;
+
+    children.forEach(dropdownMenu => {
+      if (
+        dropdownMenu.classList &&
+        dropdownMenu.classList.contains('dropdown-menu')
+      ) {
+        const cachedActiveDropdown = activeDropdown.dropdown;
+        closeDropdown({ focus: true });
+
+        if (dropdown === cachedActiveDropdown) {
+          return;
+        }
+
+        button.focus();
+        dropdown.classList.add('show');
+        dropdownMenu.classList.add('show');
+        button.setAttribute('aria-expanded', 'true');
+        activeDropdown = {
+          dropdown: dropdown,
+          button: button,
+          dropdownMenu: dropdownMenu
+        };
+      }
+    });
+  }
+
+  function closeDropdown(options = {}) {
+    if (activeDropdown.dropdown) {
+      activeDropdown.dropdown.classList.remove('show');
+      activeDropdown.dropdownMenu.classList.remove('show');
+      activeDropdown.button.setAttribute('aria-expanded', 'false');
+      if (options.focus) {
+        activeDropdown.button.focus();
+      }
+      activeDropdown = {};
+    }
+  }
+
+  function handleKeyup(event) {
+    if (activeDropdown.dropdown && event.keyCode == 27) {
+      closeDropdown({ focus: true });
+    }
+  }
+});

--- a/assets/javascripts/hootstrap/dropdown.js
+++ b/assets/javascripts/hootstrap/dropdown.js
@@ -64,7 +64,7 @@ document.addEventListener(HootstrapEvent, () => {
   }
 
   function handleKeyup(event) {
-    if (activeDropdown.dropdown && event.keyCode == 27) {
+    if (event.keyCode == 27) {
       closeDropdown({ focus: true });
     }
   }


### PR DESCRIPTION
Addresses https://github.com/ProctorU/hootstrap/issues/34.

Dropdown support is 100% data-attribute driven and is based on the same HTML implementation of [Bootstrap dropdowns](https://getbootstrap.com/docs/4.1/components/dropdowns/).

```html
<div class="dropdown">
  <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
    Dropdown button
  </button>
  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
    <a class="dropdown-item" href="#">Action</a>
    <a class="dropdown-item" href="#">Another action</a>
    <a class="dropdown-item" href="#">Something else here</a>
  </div>
</div>
```