### PR TITLE
Add Turbolinks progress bar

### DIFF
--- a/assets/javascripts/hootstrap.js
+++ b/assets/javascripts/hootstrap.js
@@ -3,3 +3,4 @@
 //= require hootstrap/modal
 //= require hootstrap/rails
 //= require hootstrap/toast
+//= require hootstrap/turbolinks-progress-bar

--- a/assets/javascripts/hootstrap.js
+++ b/assets/javascripts/hootstrap.js
@@ -1,3 +1,4 @@
+//= require hootstrap/utils/turbolinks
 //= require hootstrap/alerts
 //= require hootstrap/dropdown
 //= require hootstrap/modal

--- a/assets/javascripts/hootstrap/alerts.js
+++ b/assets/javascripts/hootstrap/alerts.js
@@ -1,8 +1,7 @@
 //= require ./utils/closest
 //= require ./utils/dynamicListener
-//= require ./utils/turbolinks
 
-document.addEventListener(Hootstrap.event, () => {
+document.addEventListener(Hootstrap.turbolinks.event, () => {
   addDynamicEventListener(
     document.body,
     'click',

--- a/assets/javascripts/hootstrap/alerts.js
+++ b/assets/javascripts/hootstrap/alerts.js
@@ -2,7 +2,7 @@
 //= require ./utils/dynamicListener
 //= require ./utils/turbolinks
 
-document.addEventListener(HootstrapEvent, () => {
+document.addEventListener(Hootstrap.event, () => {
   addDynamicEventListener(
     document.body,
     'click',

--- a/assets/javascripts/hootstrap/dropdown.js
+++ b/assets/javascripts/hootstrap/dropdown.js
@@ -1,7 +1,7 @@
 //= require ./utils/dynamicListener
 //= require ./utils/turbolinks
 
-document.addEventListener(HootstrapEvent, () => {
+document.addEventListener(Hootstrap.event, () => {
   let activeDropdown = {};
 
   addDynamicEventListener(

--- a/assets/javascripts/hootstrap/dropdown.js
+++ b/assets/javascripts/hootstrap/dropdown.js
@@ -1,7 +1,6 @@
 //= require ./utils/dynamicListener
-//= require ./utils/turbolinks
 
-document.addEventListener(Hootstrap.event, () => {
+document.addEventListener(Hootstrap.turbolinks.event, () => {
   let activeDropdown = {};
 
   addDynamicEventListener(

--- a/assets/javascripts/hootstrap/rails.js
+++ b/assets/javascripts/hootstrap/rails.js
@@ -1,7 +1,7 @@
 //= require ./utils/dynamicListener
 //= require ./utils/turbolinks
 
-document.addEventListener(HootstrapEvent, () => {
+document.addEventListener(Hootstrap.event, () => {
   let confirmed = false;
 
   addDynamicEventListener(document.body, 'click', '[data-prompt]', handleClick);

--- a/assets/javascripts/hootstrap/rails.js
+++ b/assets/javascripts/hootstrap/rails.js
@@ -1,7 +1,6 @@
 //= require ./utils/dynamicListener
-//= require ./utils/turbolinks
 
-document.addEventListener(Hootstrap.event, () => {
+document.addEventListener(Hootstrap.turbolinks.event, () => {
   let confirmed = false;
 
   addDynamicEventListener(document.body, 'click', '[data-prompt]', handleClick);

--- a/assets/javascripts/hootstrap/turbolinks-progress-bar.js
+++ b/assets/javascripts/hootstrap/turbolinks-progress-bar.js
@@ -1,10 +1,8 @@
-//= require ./utils/turbolinks
-
 // Override Turbolinks default timeout for the progress bar.
 //
 // Shows the Progress Bar after every page change.
 
-if (Hootstrap.turbolinks) {
+if (Hootstrap.turbolinks.enabled) {
   Turbolinks.BrowserAdapter.prototype.showProgressBarAfterDelay = function() {
     return (this.progressBarTimeout = setTimeout(this.showProgressBar, 0));
   };

--- a/assets/javascripts/hootstrap/turbolinks-progress-bar.js
+++ b/assets/javascripts/hootstrap/turbolinks-progress-bar.js
@@ -1,0 +1,11 @@
+//= require ./utils/turbolinks
+
+// Override Turbolinks default timeout for the progress bar.
+//
+// Shows the Progress Bar after every page change.
+
+if (Hootstrap.turbolinks) {
+  Turbolinks.BrowserAdapter.prototype.showProgressBarAfterDelay = function() {
+    return (this.progressBarTimeout = setTimeout(this.showProgressBar, 0));
+  };
+}

--- a/assets/javascripts/hootstrap/utils/turbolinks.js
+++ b/assets/javascripts/hootstrap/utils/turbolinks.js
@@ -14,6 +14,8 @@ function checkTurbolinks() {
 }
 
 window.Hootstrap = {
-  turbolinks: turbolinksEnabled,
-  event: checkTurbolinks()
+  turbolinks: {
+    enabled: turbolinksEnabled,
+    event: checkTurbolinks()
+  }
 };

--- a/assets/javascripts/hootstrap/utils/turbolinks.js
+++ b/assets/javascripts/hootstrap/utils/turbolinks.js
@@ -1,5 +1,8 @@
+const turbolinksEnabled =
+  window.Turbolinks != null && window.Turbolinks.supported;
+
 function checkTurbolinks() {
-  if (window.Turbolinks != null && window.Turbolinks.supported) {
+  if (turbolinksEnabled) {
     if (window.Turbolinks.EVENTS != null) {
       return 'page:change';
     } else {
@@ -10,4 +13,7 @@ function checkTurbolinks() {
   }
 }
 
-window.HootstrapEvent = checkTurbolinks();
+window.Hootstrap = {
+  turbolinks: turbolinksEnabled,
+  event: checkTurbolinks()
+};

--- a/assets/stylesheets/hootstrap.scss
+++ b/assets/stylesheets/hootstrap.scss
@@ -1,9 +1,9 @@
-@import "bootstrap/functions";
-@import "hootstrap/base/base";
-@import "bootstrap/variables";
-@import "bootstrap";
+@import 'bootstrap/functions';
+@import 'hootstrap/base/base';
+@import 'bootstrap/variables';
+@import 'bootstrap';
 
-@import "hootstrap/reset/base";
-@import "hootstrap/components/base";
-@import "hootstrap/patterns/base";
-@import "hootstrap/utils/base";
+@import 'hootstrap/reset/base';
+@import 'hootstrap/components/base';
+@import 'hootstrap/patterns/base';
+@import 'hootstrap/utils/base';

--- a/assets/stylesheets/hootstrap/base/_base.scss
+++ b/assets/stylesheets/hootstrap/base/_base.scss
@@ -1,5 +1,5 @@
-@import "hootstrap/base/variables";
-@import "hootstrap/base/mixins/background";
-@import "hootstrap/base/mixins/button";
-@import "hootstrap/base/mixins/toast";
-@import "hootstrap/base/mixins/tooltip";
+@import 'hootstrap/base/variables';
+@import 'hootstrap/base/mixins/background';
+@import 'hootstrap/base/mixins/button';
+@import 'hootstrap/base/mixins/toast';
+@import 'hootstrap/base/mixins/tooltip';

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -768,7 +768,7 @@ $toast-width: 400px;
 // Progress bars
 
 $progress-height: 1rem;
-$progress-height-sm: 2px;
+$progress-height-sm: 0.125rem;
 $progress-font-size: .75rem;
 $progress-bg: $gray-200;
 $progress-border-radius: $border-radius;

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -768,6 +768,7 @@ $toast-width: 400px;
 // Progress bars
 
 $progress-height: 1rem;
+$progress-height-sm: 2px;
 $progress-font-size: .75rem;
 $progress-bg: $gray-200;
 $progress-border-radius: $border-radius;

--- a/assets/stylesheets/hootstrap/components/_base.scss
+++ b/assets/stylesheets/hootstrap/components/_base.scss
@@ -3,4 +3,5 @@
 @import "hootstrap/components/button";
 @import "hootstrap/components/forms";
 @import "hootstrap/components/loader";
+@import "hootstrap/components/progress-bar";
 @import "hootstrap/components/tooltip";

--- a/assets/stylesheets/hootstrap/components/_base.scss
+++ b/assets/stylesheets/hootstrap/components/_base.scss
@@ -1,7 +1,7 @@
-@import "hootstrap/components/alert";
-@import "hootstrap/components/badge";
-@import "hootstrap/components/button";
-@import "hootstrap/components/forms";
-@import "hootstrap/components/loader";
-@import "hootstrap/components/progress-bar";
-@import "hootstrap/components/tooltip";
+@import 'hootstrap/components/alert';
+@import 'hootstrap/components/badge';
+@import 'hootstrap/components/button';
+@import 'hootstrap/components/forms';
+@import 'hootstrap/components/loader';
+@import 'hootstrap/components/progress-bar';
+@import 'hootstrap/components/tooltip';

--- a/assets/stylesheets/hootstrap/components/_progress-bar.scss
+++ b/assets/stylesheets/hootstrap/components/_progress-bar.scss
@@ -1,0 +1,4 @@
+.turbolinks-progress-bar {
+  background-color: $progress-bar-bg;
+  height: $progress-height-sm;
+}

--- a/assets/stylesheets/hootstrap/reset/_base.scss
+++ b/assets/stylesheets/hootstrap/reset/_base.scss
@@ -1,1 +1,1 @@
-@import "hootstrap/reset/html";
+@import 'hootstrap/reset/html';

--- a/assets/stylesheets/hootstrap/utils/_base.scss
+++ b/assets/stylesheets/hootstrap/utils/_base.scss
@@ -1,5 +1,5 @@
-@import "hootstrap/utils/background";
-@import "hootstrap/utils/flex";
-@import "hootstrap/utils/opacity";
-@import "hootstrap/utils/sizing";
-@import "hootstrap/utils/typography";
+@import 'hootstrap/utils/background';
+@import 'hootstrap/utils/flex';
+@import 'hootstrap/utils/opacity';
+@import 'hootstrap/utils/sizing';
+@import 'hootstrap/utils/typography';


### PR DESCRIPTION
Add _optional_ support for Turbolinks progress bar. Fail silently if no support.

![progress-bar](https://user-images.githubusercontent.com/3933204/42701433-30c0d802-868c-11e8-86e6-69219db60108.gif)
