### PR TITLE
Make it possible to override default colors

### DIFF
--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -37,16 +37,16 @@ $grays: map-merge(
   $grays
 );
 
-$blue: #0072b1;
-$indigo: #6610f2;
-$purple: #6f42c1;
-$pink: #e83e8c;
-$red: #e21c2c;
-$orange: #fd7e14;
-$yellow: #f3bf51;
-$green: #008761;
-$teal: #20c997;
-$cyan: #bfdbf7;
+$blue: #0072b1 !default;
+$indigo: #6610f2 !default;
+$purple: #6f42c1 !default;
+$pink: #e83e8c !default;
+$red: #e21c2c !default;
+$orange: #fd7e14 !default;
+$yellow: #f3bf51 !default;
+$green: #008761 !default;
+$teal: #20c997 !default;
+$cyan: #bfdbf7 !default;
 
 $colors: ();
 $colors: map-merge(


### PR DESCRIPTION
When I continued implementing this into my personal apps,  I needed to be able to override the default colors. 

Upon looking into how we'd do it for Bootstrap 4 (https://github.com/twbs/bootstrap/issues/23112). It looks like we were missing the !default on the colors. 

Adding it back allows apps to override it in their scss files. 