### PR TITLE
Import changes from 4.0..4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - No changes.
 
+## 0.9.0 - 2018-12-07
+
+### Added
+
+- No changes.
+
+### Changed
+
+- Bump support from Bootstrap 4 to Bootstrap 4.1. [#50](https://github.com/ProctorU/hootstrap/pull/50) [Credit: Andrew Fomera - @king601]
+
+### Removed
+
+- No changes.
+
 ## 0.8.0 - 2018-12-07
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hootstrap (0.8.0)
+    hootstrap (0.9.0)
       bootstrap (~> 4.1.3)
       rails (>= 4.2.0)
       sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     hootstrap (0.8.0)
-      bootstrap (~> 4.0.0)
+      bootstrap (~> 4.1.3)
       rails (>= 4.2.0)
       sass-rails
 
@@ -53,7 +53,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.4.2)
       execjs
-    bootstrap (4.0.0)
+    bootstrap (4.1.3)
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -119,7 +119,7 @@ $spacers: (
 );
 
 // This variable affects the `.h-*` and `.w-*` classes.
-$sizes: (25: 25%, 50: 50%, 75: 75%, 100: 100%);
+$sizes: (25: 25%, 50: 50%, 75: 75%, 100: 100%, auto: auto);
 
 // Body
 //
@@ -187,6 +187,10 @@ $border-radius: 0.25rem;
 $border-radius-lg: 0.3rem;
 $border-radius-sm: 0.2rem;
 
+$box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
+$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
+$box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
+
 $box-shadow: 0 0 0 1px rgba(62, 64, 64, 0.05), 0 1px 3px rgba(62, 64, 64, 0.1),
   0 1px 2px rgba(0, 0, 0, 0.05);
 
@@ -206,7 +210,7 @@ $transition-collapse: height 0.35s ease;
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
   "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-  "Segoe UI Symbol";
+  "Segoe UI Symbol", "Noto Color Emoji";
 $font-family-monospace: "SFMono-Regular", Menlo, Monaco, Consolas,
   "Liberation Mono", "Courier New", monospace;
 $font-family-base: $font-family-sans-serif;
@@ -300,6 +304,9 @@ $table-dark-hover-bg: rgba($white, .075);
 $table-dark-border-color: lighten($gray-900, 7.5%);
 $table-dark-color: $body-bg;
 
+$table-striped-order: odd;
+$table-caption-color: $text-muted;
+
 // Buttons
 //
 // For each of Bootstrap's buttons, define text, background and border color.
@@ -343,6 +350,7 @@ $btn-transition: background-color .15s ease-in-out,
 
 // Forms
 
+$label-margin-bottom: .5rem !default;
 $input-bg: $white;
 $input-disabled-bg: $gray-200;
 
@@ -361,6 +369,7 @@ $input-focus-box-shadow: $input-btn-focus-box-shadow;
 $input-focus-color: $input-color;
 
 $input-placeholder-color: $gray-600;
+$input-plaintext-color: $body-color;
 
 $input-height-border: $input-btn-border-width * 2;
 
@@ -399,6 +408,9 @@ $form-group-error-padding-y: 0.1rem;
 $input-group-addon-color: $input-color;
 $input-group-addon-bg: $gray-200;
 $input-group-addon-border-color: $input-border-color;
+
+
+$custom-forms-transition: background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 
 $custom-control-gutter: 1.5rem;
 $custom-control-spacer-y: .25rem;
@@ -453,7 +465,7 @@ $custom-select-indicator-padding: 1rem; // Extra padding to account for the pres
 $custom-select-line-height: $input-btn-line-height;
 $custom-select-color: $input-color;
 $custom-select-disabled-color: $gray-600;
-$custom-select-bg: $white;
+$custom-select-bg: $input-bg;
 $custom-select-disabled-bg: $gray-200;
 $custom-select-bg-size: 8px 10px; // In pixels because image dimensions
 $custom-select-indicator-color: #333;
@@ -465,17 +477,37 @@ $custom-select-indicator: str-replace(
 $custom-select-border-width: $input-btn-border-width;
 $custom-select-border-color: $input-border-color;
 $custom-select-border-radius: $border-radius;
+$custom-select-box-shadow: inset 0 1px 2px rgba($black, .075);
 
 $custom-select-focus-border-color: $input-focus-border-color;
-$custom-select-focus-box-shadow: $input-focus-box-shadow;
+$custom-select-focus-width: $input-btn-focus-width;
+$custom-select-focus-box-shadow: 0 0 0 $custom-select-focus-width rgba($custom-select-focus-border-color, .5);
 
 $custom-select-font-size-sm: 75%;
 $custom-select-height-sm: $input-height-sm;
 
+$custom-range-track-width: 100% !default;
+$custom-range-track-height: .5rem !default;
+$custom-range-track-cursor: pointer !default;
+$custom-range-track-bg: $gray-300 !default;
+$custom-range-track-border-radius:  1rem !default;
+$custom-range-track-box-shadow: inset 0 .25rem .25rem rgba($black, .1) !default;
+$custom-range-thumb-width: 1rem !default;
+$custom-range-thumb-height: $custom-range-thumb-width !default;
+$custom-range-thumb-bg: $component-active-bg !default;
+$custom-range-thumb-border: 0 !default;
+$custom-range-thumb-border-radius: 1rem !default;
+$custom-range-thumb-box-shadow: 0 .1rem .25rem rgba($black, .1) !default;
+$custom-range-thumb-focus-box-shadow: 0 0 0 1px $body-bg, $input-btn-focus-box-shadow !default;
+$custom-range-thumb-focus-box-shadow-width: $input-btn-focus-width !default; // For focus box shadow issue in IE/Edge
+$custom-range-thumb-active-bg: lighten($component-active-bg, 35%) !default;
+
 $custom-file-height: $input-height;
+$custom-file-height-inner: $input-height-inner;
 $custom-file-width: 14rem;
 $custom-file-focus-box-shadow: 0 0 0 .075rem $white,
   0 0 0 .2rem theme-color("primary");
+$custom-file-disabled-bg: $input-disabled-bg;
 
 $custom-file-padding-y: $input-btn-padding-y;
 $custom-file-padding-x: $input-btn-padding-x;
@@ -561,6 +593,9 @@ $nav-tabs-link-active-border-color: #ddd;
 $nav-pills-border-radius: $border-radius;
 $nav-pills-link-active-color: $component-active-color;
 $nav-pills-link-active-bg: $component-active-bg;
+
+$nav-divider-color: $gray-200;
+$nav-divider-margin-y: ($spacer / 2);
 
 // Navbar
 
@@ -828,7 +863,9 @@ $breadcrumb-margin-bottom: 1rem;
 $breadcrumb-bg: $gray-200;
 $breadcrumb-divider-color: $gray-600;
 $breadcrumb-active-color: $gray-600;
-$breadcrumb-divider: "/";
+$breadcrumb-divider: quote("/");
+
+$breadcrumb-border-radius: $border-radius;
 
 // Carousel
 

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -187,9 +187,9 @@ $border-radius: 0.25rem;
 $border-radius-lg: 0.3rem;
 $border-radius-sm: 0.2rem;
 
-$box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
-$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
-$box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
+$box-shadow-sm: 0 .125rem .25rem rgba($black, .075);
+$box-shadow: 0 .5rem 1rem rgba($black, .15);
+$box-shadow-lg: 0 1rem 3rem rgba($black, .175);
 
 $box-shadow: 0 0 0 1px rgba(62, 64, 64, 0.05), 0 1px 3px rgba(62, 64, 64, 0.1),
   0 1px 2px rgba(0, 0, 0, 0.05);
@@ -350,7 +350,7 @@ $btn-transition: background-color .15s ease-in-out,
 
 // Forms
 
-$label-margin-bottom: .5rem !default;
+$label-margin-bottom: .5rem;
 $input-bg: $white;
 $input-disabled-bg: $gray-200;
 
@@ -486,21 +486,21 @@ $custom-select-focus-box-shadow: 0 0 0 $custom-select-focus-width rgba($custom-s
 $custom-select-font-size-sm: 75%;
 $custom-select-height-sm: $input-height-sm;
 
-$custom-range-track-width: 100% !default;
-$custom-range-track-height: .5rem !default;
-$custom-range-track-cursor: pointer !default;
-$custom-range-track-bg: $gray-300 !default;
-$custom-range-track-border-radius:  1rem !default;
-$custom-range-track-box-shadow: inset 0 .25rem .25rem rgba($black, .1) !default;
-$custom-range-thumb-width: 1rem !default;
-$custom-range-thumb-height: $custom-range-thumb-width !default;
-$custom-range-thumb-bg: $component-active-bg !default;
-$custom-range-thumb-border: 0 !default;
-$custom-range-thumb-border-radius: 1rem !default;
-$custom-range-thumb-box-shadow: 0 .1rem .25rem rgba($black, .1) !default;
-$custom-range-thumb-focus-box-shadow: 0 0 0 1px $body-bg, $input-btn-focus-box-shadow !default;
-$custom-range-thumb-focus-box-shadow-width: $input-btn-focus-width !default; // For focus box shadow issue in IE/Edge
-$custom-range-thumb-active-bg: lighten($component-active-bg, 35%) !default;
+$custom-range-track-width: 100%;
+$custom-range-track-height: .5rem;
+$custom-range-track-cursor: pointer;
+$custom-range-track-bg: $gray-300;
+$custom-range-track-border-radius:  1rem;
+$custom-range-track-box-shadow: inset 0 .25rem .25rem rgba($black, .1);
+$custom-range-thumb-width: 1rem;
+$custom-range-thumb-height: $custom-range-thumb-width;
+$custom-range-thumb-bg: $component-active-bg;
+$custom-range-thumb-border: 0;
+$custom-range-thumb-border-radius: 1rem;
+$custom-range-thumb-box-shadow: 0 .1rem .25rem rgba($black, .1);
+$custom-range-thumb-focus-box-shadow: 0 0 0 1px $body-bg, $input-btn-focus-box-shadow;
+$custom-range-thumb-focus-box-shadow-width: $input-btn-focus-width; // For focus box shadow issue in IE/Edge
+$custom-range-thumb-active-bg: lighten($component-active-bg, 35%);
 
 $custom-file-height: $input-height;
 $custom-file-height-inner: $input-height-inner;

--- a/hootstrap.gemspec
+++ b/hootstrap.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 4.2.0'
   s.add_dependency 'sass-rails'
-  s.add_dependency 'bootstrap', '~> 4.0.0'
+  s.add_dependency 'bootstrap', '~> 4.1.3'
 end

--- a/lib/hootstrap/version.rb
+++ b/lib/hootstrap/version.rb
@@ -1,3 +1,3 @@
 module Hootstrap
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
Update us to support 4.1 of Bootstrap 4.

Per this PR #29 we needed to go through the changes and ensure our variables lined up.

Here's the link to Bootstraps changes: https://github.com/twbs/bootstrap/compare/v4.0.0...v4.1.3

I searched _variables.scss and copied over those. Removing !default from their code. Otherwise it's a 1:1 copy from those diffs.

Tested on my personal apps and they appear to work great with no changes. 