### PR TITLE
Increase $gray-600 contrast against white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - No changes.
 
+## 0.10.0 - 2018-12-14
+
+### Added
+
+- No changes.
+
+### Changed
+
+- Increase $gray-600 contrast against white [#58](https://github.com/ProctorU/hootstrap/pull/58) [Credit: Justin Licata @licatajustin]
+
+### Removed
+
+- No changes.
+
 ## 0.9.0 - 2018-12-07
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hootstrap (0.9.0)
+    hootstrap (0.10.0)
       bootstrap (~> 4.1.3)
       rails (>= 4.2.0)
       sass-rails
@@ -65,7 +65,7 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    i18n (1.1.1)
+    i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -14,7 +14,7 @@ $gray-200: #e9ecef;
 $gray-300: #dee2e6;
 $gray-400: #ced4da;
 $gray-500: #adb5bd;
-$gray-600: #868e96;
+$gray-600: #6b7580;
 $gray-700: #495057;
 $gray-800: #343a40;
 $gray-900: #212529;

--- a/lib/hootstrap/version.rb
+++ b/lib/hootstrap/version.rb
@@ -1,3 +1,3 @@
 module Hootstrap
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
Improves the `$gray-600` color, which is our default `$gray`, and makes it accessible with white text.