### PR TITLE
Update $page-subtitle-color to be according WCAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - No changes.
 
+## 0.12.1 - 2019-10-16
+
+### Added
+
+- No changes.
+
+### Changed
+
+- Update `$page-subtitle-color` to be according to WCAG [#75](https://github.com/ProctorU/hootstrap/pull/75)
+
+### Removed
+
+- No changes.
+
+
 ## 0.12.0 - 2019-04-01
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hootstrap (0.12.0)
+    hootstrap (0.12.1)
       bootstrap (~> 4.1.3)
       rails (>= 4.2.0)
       sass-rails

--- a/assets/stylesheets/hootstrap/base/_variables.scss
+++ b/assets/stylesheets/hootstrap/base/_variables.scss
@@ -643,7 +643,7 @@ $navbar-light-toggler-border-color: rgba($black, .1);
 
 $page-header-margin-y: 3rem;
 $page-title-color: inherit;
-$page-subtitle-color: $gray-600;
+$page-subtitle-color: $gray-800;
 
 // Pagination
 

--- a/lib/hootstrap/version.rb
+++ b/lib/hootstrap/version.rb
@@ -1,3 +1,3 @@
 module Hootstrap
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/lib/hootstrap/version.rb
+++ b/lib/hootstrap/version.rb
@@ -1,3 +1,3 @@
 module Hootstrap
-  VERSION = '0.12.1'
+  VERSION = '0.12.1'.freeze
 end


### PR DESCRIPTION
$page-subtitle-color now uses $gray-800 to have a good contrast with #F5F7FA and #FFFFFF. In a lot of pages #F5F7FA is the background, so that's why I choose gray-800.


More information, check this website: https://webaim.org/resources/contrastchecker/